### PR TITLE
pic/nopic project setup fixes

### DIFF
--- a/neo/sys/osx/Doom3.xcodeproj/project.pbxproj
+++ b/neo/sys/osx/Doom3.xcodeproj/project.pbxproj
@@ -7,9 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2DFD49DB147F60B100C51B13 /* game.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 81225B8B0912C731005D34B9 /* game.dylib */; };
-		2DFD49DC147F60B100C51B13 /* game.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 25DD88370B31F5F00079B759 /* game.dylib */; };
-		2DFD49DD147F60B100C51B13 /* libidlib_pic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 812259800912BF1D005D34B9 /* libidlib_pic.a */; };
+		658BACB01B643E8100B1816F /* game.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 25DD88370B31F5F00079B759 /* game.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		658BACB11B643E9200B1816F /* game.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 81225B8B0912C731005D34B9 /* game.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		812258110912BC79005D34B9 /* snd_efxfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8122565F0912BC78005D34B9 /* snd_efxfile.cpp */; };
 		812258120912BC79005D34B9 /* GEWindowWrapper_stub.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 812256620912BC78005D34B9 /* GEWindowWrapper_stub.cpp */; };
 		812258130912BC79005D34B9 /* edit_stub.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 812256630912BC79005D34B9 /* edit_stub.cpp */; };
@@ -251,6 +250,13 @@
 			remoteGlobalIDString = D2AAC0630554660B00DB518D;
 			remoteInfo = game;
 		};
+		658BACAB1B643C8600B1816F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 25DD882E0B31F5F00079B759 /* d3xp.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = D2AAC0620554660B00DB518D;
+			remoteInfo = "game-d3xp";
+		};
 		8122597F0912BF1D005D34B9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 812259790912BF1D005D34B9 /* idlib.xcodeproj */;
@@ -301,6 +307,20 @@
 			remoteInfo = game;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		658BACAF1B643E7000B1816F /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 7;
+			files = (
+				658BACB11B643E9200B1816F /* game.dylib in CopyFiles */,
+				658BACB01B643E8100B1816F /* game.dylib in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		089C165DFE840E0CC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -677,9 +697,6 @@
 				D7D7BBEB189532E6000A495C /* Carbon.framework in Frameworks */,
 				D7D7BBE9189532D9000A495C /* Cocoa.framework in Frameworks */,
 				D796927A17607FEE00A42598 /* libcurl.dylib in Frameworks */,
-				2DFD49DB147F60B100C51B13 /* game.dylib in Frameworks */,
-				2DFD49DC147F60B100C51B13 /* game.dylib in Frameworks */,
-				2DFD49DD147F60B100C51B13 /* libidlib_pic.a in Frameworks */,
 				812259940912BF87005D34B9 /* liboggVorbis_nopic.a in Frameworks */,
 				812259930912BF7F005D34B9 /* libidlib_nopic.a in Frameworks */,
 			);
@@ -1291,10 +1308,12 @@
 				8D1107290486CEB800E47090 /* Resources */,
 				8D11072C0486CEB800E47090 /* Sources */,
 				8D11072E0486CEB800E47090 /* Frameworks */,
+				658BACAF1B643E7000B1816F /* CopyFiles */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				658BACAC1B643C8600B1816F /* PBXTargetDependency */,
 				812259840912BF2B005D34B9 /* PBXTargetDependency */,
 				812259910912BF43005D34B9 /* PBXTargetDependency */,
 				81225B8D0912C73C005D34B9 /* PBXTargetDependency */,
@@ -1633,6 +1652,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		658BACAC1B643C8600B1816F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "game-d3xp";
+			targetProxy = 658BACAB1B643C8600B1816F /* PBXContainerItemProxy */;
+		};
 		812259840912BF2B005D34B9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = idlib_nopic;

--- a/neo/sys/osx/d3xp.xcodeproj/project.pbxproj
+++ b/neo/sys/osx/d3xp.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 		81225AC10912C42F005D34B9 /* Weapon.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = Weapon.h; path = ../../d3xp/Weapon.h; sourceTree = SOURCE_ROOT; };
 		81225AC20912C42F005D34B9 /* WorldSpawn.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = WorldSpawn.cpp; path = ../../d3xp/WorldSpawn.cpp; sourceTree = SOURCE_ROOT; };
 		81225AC30912C42F005D34B9 /* WorldSpawn.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = WorldSpawn.h; path = ../../d3xp/WorldSpawn.h; sourceTree = SOURCE_ROOT; };
-		D2AAC0630554660B00DB518D /* game.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = game.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2AAC0630554660B00DB518D /* d3xp.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = d3xp.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -402,7 +402,7 @@
 		1AB674ADFE9D54B511CA2CBB /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				D2AAC0630554660B00DB518D /* game.dylib */,
+				D2AAC0630554660B00DB518D /* d3xp.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -606,9 +606,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		D2AAC0620554660B00DB518D /* game-d3xp */ = {
+		D2AAC0620554660B00DB518D /* d3xp */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 81225A240912C3A4005D34B9 /* Build configuration list for PBXNativeTarget "game-d3xp" */;
+			buildConfigurationList = 81225A240912C3A4005D34B9 /* Build configuration list for PBXNativeTarget "d3xp" */;
 			buildPhases = (
 				D2AAC0600554660B00DB518D /* Headers */,
 				D2AAC0610554660B00DB518D /* Sources */,
@@ -619,9 +619,9 @@
 			dependencies = (
 				81225A390912C3C8005D34B9 /* PBXTargetDependency */,
 			);
-			name = "game-d3xp";
+			name = d3xp;
 			productName = game;
-			productReference = D2AAC0630554660B00DB518D /* game.dylib */;
+			productReference = D2AAC0630554660B00DB518D /* d3xp.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */
@@ -648,7 +648,7 @@
 			);
 			projectRoot = "";
 			targets = (
-				D2AAC0620554660B00DB518D /* game-d3xp */,
+				D2AAC0620554660B00DB518D /* d3xp */,
 			);
 		};
 /* End PBXProject section */
@@ -786,7 +786,7 @@
 					"-fpermissive",
 				);
 				PREBINDING = NO;
-				PRODUCT_NAME = game;
+				PRODUCT_NAME = d3xp;
 				ZERO_LINK = YES;
 			};
 			name = Debug;
@@ -816,7 +816,7 @@
 					"-fpermissive",
 				);
 				PREBINDING = NO;
-				PRODUCT_NAME = game;
+				PRODUCT_NAME = d3xp;
 				SYMROOT = build;
 				ZERO_LINK = NO;
 			};
@@ -849,7 +849,7 @@
 					"-fpermissive",
 				);
 				PREBINDING = NO;
-				PRODUCT_NAME = game;
+				PRODUCT_NAME = d3xp;
 			};
 			name = Default;
 		};
@@ -919,7 +919,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		81225A240912C3A4005D34B9 /* Build configuration list for PBXNativeTarget "game-d3xp" */ = {
+		81225A240912C3A4005D34B9 /* Build configuration list for PBXNativeTarget "d3xp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				81225A250912C3A4005D34B9 /* Debug */,


### PR DESCRIPTION
Hi, this should fix your problems with that nasty heap assertion:

Don't link game.dylib directly into the executable, properly use the idlib pic
and nopic versions. Renamed lib for d3xp to "d3xp" (from "game-d3xp").
